### PR TITLE
Add Action to Publish a Project

### DIFF
--- a/.github/workflows/publish_project.yaml
+++ b/.github/workflows/publish_project.yaml
@@ -1,0 +1,54 @@
+# This workflow will publish a project from the private TA repo
+# to the public student repo
+
+name: Publish Project
+
+on:
+  # Run this workflow with a manual trigger from GitHub Actions
+  workflow_dispatch:
+    inputs: 
+      organization:
+        description: "name of the organization"
+        required: true
+
+      project:
+        description: "name of project"
+        required: true
+
+jobs:
+  # This job will publish the project from the TA repo to the Public Repo
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout Private Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          repository: '${{github.event.inputs.organization}}/${{github.event.inputs.organization}}-ta'
+          token: ${{ secrets.TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "publish-bot@umd.cmsc389T"
+          git config --global user.name "Publish Bot"
+      
+      - name: Pull Changes
+        working-directory: public
+        run: git pull
+
+      - name: Copy Project
+        run: | 
+          cp -r "Projects/${{github.event.inputs.project}}" "public/Projects/${{github.event.inputs.project}}"
+
+      - name: Publish Changes
+        run: | 
+          git add "Projects/${{github.event.inputs.project}}"
+          git commit -m "Publish Bot: Publish ${{github.event.inputs.project}}"
+          git push -u origin main
+
+      - name: Update Submodule Reference
+        run: |
+          git add public
+          git commit -m "Publish Bot: Released ${{github.event.inputs.project}}"
+          git push -u origin main

--- a/.github/workflows/publish_project.yaml
+++ b/.github/workflows/publish_project.yaml
@@ -4,6 +4,7 @@
 name: Publish Project
 
 on:
+  push:
   # Run this workflow with a manual trigger from GitHub Actions
   workflow_dispatch:
     inputs: 

--- a/.github/workflows/publish_project.yaml
+++ b/.github/workflows/publish_project.yaml
@@ -38,8 +38,7 @@ jobs:
         run: git pull
              
       - name: Copy Project
-        run: | 
-          cp -r "Projects/${{github.event.inputs.project}}" "public/Projects/"
+        run: cp -r "Projects/${{github.event.inputs.project}}" "public/Projects/"
 
       - name: Publish Changes
         run: | 

--- a/.github/workflows/publish_project.yaml
+++ b/.github/workflows/publish_project.yaml
@@ -35,8 +35,8 @@ jobs:
       
       - name: Pull Changes
         working-directory: public
-        run: git pull
-
+        run: git pull && ls
+             
       - name: Copy Project
         run: | 
           cp -r "Projects/${{github.event.inputs.project}}" "public/Projects/${{github.event.inputs.project}}"

--- a/.github/workflows/publish_project.yaml
+++ b/.github/workflows/publish_project.yaml
@@ -35,7 +35,9 @@ jobs:
       
       - name: Pull Changes
         working-directory: public
-        run: git pull
+        run: |
+          git checkout main
+          git pull
              
       - name: Copy Project
         run: cp -r "Projects/${{github.event.inputs.project}}" "public/Projects/"

--- a/.github/workflows/publish_project.yaml
+++ b/.github/workflows/publish_project.yaml
@@ -35,11 +35,11 @@ jobs:
       
       - name: Pull Changes
         working-directory: public
-        run: git pull && ls
+        run: git pull
              
       - name: Copy Project
         run: | 
-          cp -r "Projects/${{github.event.inputs.project}}" "public/Projects/${{github.event.inputs.project}}"
+          cp -r "Projects/${{github.event.inputs.project}}" "public/Projects/"
 
       - name: Publish Changes
         run: | 

--- a/.github/workflows/publish_project.yaml
+++ b/.github/workflows/publish_project.yaml
@@ -4,7 +4,6 @@
 name: Publish Project
 
 on:
-  push:
   # Run this workflow with a manual trigger from GitHub Actions
   workflow_dispatch:
     inputs: 

--- a/.github/workflows/publish_project.yaml
+++ b/.github/workflows/publish_project.yaml
@@ -41,6 +41,7 @@ jobs:
         run: cp -r "Projects/${{github.event.inputs.project}}" "public/Projects/"
 
       - name: Publish Changes
+        working-directory: public
         run: | 
           git add "Projects/${{github.event.inputs.project}}"
           git commit -m "Publish Bot: Publish ${{github.event.inputs.project}}"


### PR DESCRIPTION
## Summary of Changes
In this PR, I have included a new action `Publish Project` that publishes a project from the private TA repository to the public class repository. 

## Motivation
Whenever facilitators release projects for students to work with, we take a series of steps to publish a project for the class. This action automates those steps as outlined in https://github.com/sagars729/CMSC389T-Toolbox/issues/3.

## Testing
This PR was tested by running it with releasing Project 0 for CMSC389T in Fall 2022 by running the following command

```bash
gh workflow run 'Publish Project' --ref publish-project -f organization=cmsc389T-fall22 -f project=P0
```

Workflow Run: https://github.com/sagars729/CMSC389T-Toolbox/actions/runs/2958390269