### PR TITLE
Publish project submodule

### DIFF
--- a/.github/workflows/publish_project_submodule.yaml
+++ b/.github/workflows/publish_project_submodule.yaml
@@ -1,0 +1,53 @@
+# This workflow will create a new repo from a template and add it to
+# the public student repo as a submodule
+
+name: Publish Project
+
+on:
+  push:
+  # Run this workflow with a manual trigger from GitHub Actions
+  workflow_dispatch:
+    inputs: 
+      organization:
+        description: "name of the organization"
+        required: true
+
+      project:
+        description: "name of project to add to"
+        required: true
+
+      template:
+        description: "template to create submodule from"
+        required: true
+
+      name:
+        description: "name of new submodule"
+        required: true
+
+jobs:
+  # This job will publish the project from the TA repo to the Public Repo
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout Public Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          repository: '${{github.event.inputs.organization}}/${{github.event.inputs.organization}}'
+          token: ${{ secrets.TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "publish-bot@umd.cmsc389T"
+          git config --global user.name "Publish Bot"
+
+      - name: Create Repo From Template
+        run: gh repo create '${{github.event.inputs.organization}}/${{github.event.inputs.name}}' --template '${{github.event.inputs.template}}' --team 'facilitators' --public
+
+      - name: Add Submodule
+        run: | 
+          git submodule add 'https://github.com/${{github.event.inputs.organization}}/${{github.event.inputs.name}}.git' 'Projects/${{github.event.inputs.project}}/${{github.event.inputs.name}}' 
+          git add 'Projects/${{github.event.inputs.project}}/${{github.event.inputs.name}}'
+          git commit -m 'Publish Bot: Add Submodule ${{github.event.inputs.name}} to ${{github.event.inputs.project}}'
+          git push -u origin main

--- a/.github/workflows/publish_project_submodule.yaml
+++ b/.github/workflows/publish_project_submodule.yaml
@@ -4,7 +4,6 @@
 name: Publish Project Submodule
 
 on:
-  push:
   # Run this workflow with a manual trigger from GitHub Actions
   workflow_dispatch:
     inputs: 

--- a/.github/workflows/publish_project_submodule.yaml
+++ b/.github/workflows/publish_project_submodule.yaml
@@ -44,7 +44,9 @@ jobs:
       - name: Create Repo From Template
         env:
           GH_TOKEN: ${{ secrets.TOKEN }}
-        run: gh repo create '${{github.event.inputs.organization}}/${{github.event.inputs.name}}' --template '${{github.event.inputs.template}}' --team 'facilitators' --public
+        run: |
+          gh repo create '${{github.event.inputs.organization}}/${{github.event.inputs.name}}' --template '${{github.event.inputs.template}}' --public
+          gh api -X PUT '/orgs/${{github.event.inputs.organization}}/teams/facilitators/repos/${{github.event.inputs.organization}}/${{github.event.inputs.name}}' -F permission='push'
 
       - name: Add Submodule
         run: | 

--- a/.github/workflows/publish_project_submodule.yaml
+++ b/.github/workflows/publish_project_submodule.yaml
@@ -1,5 +1,5 @@
 # This workflow will create a new repo from a template and add it to
-# the public student repo as a submodule
+# the public student repo as a submodule.
 
 name: Publish Project Submodule
 

--- a/.github/workflows/publish_project_submodule.yaml
+++ b/.github/workflows/publish_project_submodule.yaml
@@ -1,7 +1,7 @@
 # This workflow will create a new repo from a template and add it to
 # the public student repo as a submodule
 
-name: Publish Project
+name: Publish Project Submodule
 
 on:
   push:

--- a/.github/workflows/publish_project_submodule.yaml
+++ b/.github/workflows/publish_project_submodule.yaml
@@ -43,6 +43,8 @@ jobs:
           git config --global user.name "Publish Bot"
 
       - name: Create Repo From Template
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN }}
         run: gh repo create '${{github.event.inputs.organization}}/${{github.event.inputs.name}}' --template '${{github.event.inputs.template}}' --team 'facilitators' --public
 
       - name: Add Submodule

--- a/README.md
+++ b/README.md
@@ -28,14 +28,13 @@ that hosts all repositories and teams for students and facilitators. The
 `Setup Organization` action will set up a new organization with teams and
 starter repositories. 
 
-### Parameters
+#### Parameters
 
 - organization: the name of the organization to set up
 - admins: a space separated list of admin github usernames
 
-### Example
+#### Example
 
-From the command line,
 ```bash
 gh workflow run 'Setup Organization' --ref main -f organization=cmsc389T-fall22 \
   -f admins='sagars729 nkrishnan19 username3 username4'
@@ -45,19 +44,41 @@ gh workflow run 'Setup Organization' --ref main -f organization=cmsc389T-fall22 
 
 For this class, we keep two repositories: a private TA repository that contains
 all projects before they are released (for internal development) and a public
-student repo that contains finalized polished versions of those projects. The
-`Publish Project` action allows facilitators to publish a project from the
+student repo that contains finalized polished versions of those projects. 
+
+### Publishing a Project
+The `Publish Project` action allows facilitators to publish a project from the
 private repository to the public repository.
 
-### Parameters
+#### Parameters
 
 - organization: the name of the organization that we are updating
 - project: the name of the project that is being published/updated
 
-### Example
+#### Example
 
-From the command line,
 ```bash
 gh workflow run 'Publish Project' --ref main -f organization=cmsc389T-fall22 \
   -f project=P0
+```
+
+### Adding a Submodule to a Project
+
+Some projects will require a linked submodule that is generated
+from a template repository. The `Publish Project Submodule` action
+creates a new repository in the organization from a template and 
+adds that new repo as a submodule to an existing project. 
+
+#### Parameters
+
+- organization: the name of the organization that we are updating
+- project: the name of the project that is being published/updated
+- template: the template repository used to create the new submodule
+- name: the new name of the submodule
+
+#### Example
+
+```bash
+gh workflow run 'Publish Project Submodule' --ref main -f organization=cmsc389T-fall22 \
+  -f project=P0 -f template=sagars729/git-java-setup-template --name=git-java-setup
 ```


### PR DESCRIPTION
## Summary of Changes
In this PR I have included a new action `Publish Project Submodule` that creates and publishes a new submodule into the public student repository.

## Motivation
Some projects require adding a submodule that remains consistent throughout semesters. This action automates that process.

Closes https://github.com/sagars729/CMSC389T-Toolbox/issues/6.

## Testing
This action was tested manually by running the following command

```bash
gh workflow run 'Publish Project Submodule' --ref publish-project-submodule \
  -f organization=cmsc389T-fall22 -f project=P0 -f name=git-java-setup \
  -f template=sagars729/git-java-setup-template
```

Workflow Run: https://github.com/sagars729/CMSC389T-Toolbox/actions/runs/2959715585
