### PR TITLE
Add create team action

### DIFF
--- a/.github/workflows/create_team.yaml
+++ b/.github/workflows/create_team.yaml
@@ -45,8 +45,8 @@ jobs:
           GH_TOKEN: ${{ secrets.TOKEN }}
         run: |
           TEAM=`gh api -X GET "/orgs/${{github.event.inputs.organization}}/teams/${{github.event.inputs.team}}" --jq ".id"`
-          gh api -X POST "/orgs/${{github.event.inputs.organization}}/repos" -F name=$1 -F private=true -F team_id=$TEAM
-          gh api -X PUT "/orgs/${{github.event.inputs.organization}}/teams/${{github.event.inputs.team}}/repos/${{github.event.inputs.organization}}/$1" -F permission=push
+          gh api -X POST "/orgs/${{github.event.inputs.organization}}/repos" -F name=${{github.event.inputs.team}} -F private=true -F team_id=$TEAM
+          gh api -X PUT "/orgs/${{github.event.inputs.organization}}/teams/${{github.event.inputs.team}}/repos/${{github.event.inputs.organization}}/${{github.event.inputs.team}}" -F permission=push
       
       - name: Configure Git
         run: |

--- a/.github/workflows/create_team.yaml
+++ b/.github/workflows/create_team.yaml
@@ -57,9 +57,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TOKEN }}
         run: |
-          git clone --bare https://github.com:${{github.event.inputs.organization}}/${{github.event.inputs.organization}}.git
+          git clone --bare https://github.com/${{github.event.inputs.organization}}/${{github.event.inputs.organization}}.git
           cd ${{github.event.inputs.organization}}.git
-          git push --mirror https://${{secrets.TOKEN}}@github.com:${{github.event.inputs.organization}}/${{github.event.inputs.team}}.git
+          git push --mirror https://${{secrets.TOKEN}}@github.com/${{github.event.inputs.organization}}/${{github.event.inputs.team}}.git
           cd ..
           rm -rf ${{github.event.inputs.organization}}.git
       

--- a/.github/workflows/create_team.yaml
+++ b/.github/workflows/create_team.yaml
@@ -3,6 +3,7 @@
 name: Publish Project
 
 on:
+  push:
   # Run this workflow with a manual trigger from GitHub Actions
   workflow_dispatch:
     inputs: 

--- a/.github/workflows/create_team.yaml
+++ b/.github/workflows/create_team.yaml
@@ -1,0 +1,79 @@
+# This workflow will create a new team 
+
+name: Publish Project
+
+on:
+  # Run this workflow with a manual trigger from GitHub Actions
+  workflow_dispatch:
+    inputs: 
+      organization:
+        description: "name of the organization"
+        required: true
+        
+      team:
+        description: "name of the team"
+        required: true
+      
+      members:
+        description: "space separated list of member usernames"
+        required: true
+
+jobs:
+  # This job will publish the project from the TA repo to the Public Repo
+  create_team:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Create Team Within Students Team
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          PARENT_TEAM=`gh api -X GET "/orgs/${{github.event.inputs.organization}}}/teams/students" --jq ".id"`
+          gh api -X POST "/orgs/${{github.event.inputs.organization}}}/teams" -F name=${{github.event.inputs.team}}} -F parent_team_id=$PARENT_TEAM
+
+      - name: Add Students to New Team
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          for student in ${{github.event.inputs.members}}
+          do
+            gh api -X PUT "/orgs/${{github.event.inputs.organization}}/teams/${{github.event.inputs.team}}/memberships/$student" 
+          done
+      
+      - name: Create Team Repository
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          TEAM=`gh api -X GET "/orgs/${{github.event.inputs.organization}}/teams/${{github.event.inputs.team}}" --jq ".id"`
+          gh api -X POST "/orgs/${{github.event.inputs.organization}}/repos" -F name=$1 -F private=true -F team_id=$TEAM
+          gh api -X PUT "/orgs/${{github.event.inputs.organization}}/teams/${{github.event.inputs.team}}/repos/${{github.event.inputs.organization}}/$1" -F permission=push
+      
+      - name: Configure Git
+        run: |
+          git config --global user.email "setup-bot@umd.cmsc389T"
+          git config --global user.name "Setup Bot"
+      
+      - name: Mirror Public Repository
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          git clone --bare https://github.com:${{github.event.inputs.organization}}/${{github.event.inputs.organization}}.git
+          cd ${{github.event.inputs.organization}}.git
+          git push --mirror https://${{secrets.TOKEN}}@github.com:${{github.event.inputs.organization}}/${{github.event.inputs.team}}.git
+          cd ..
+          rm -rf ${{github.event.inputs.organization}}.git
+      
+      - name: Checkout Team Repository
+        uses: actions/checkout@v3
+        with:
+          repository: '${{github.event.inputs.organization}}/${{github.event.inputs.team}}'
+          token: ${{ secrets.TOKEN }}
+      
+      - name: Create Feature Branches
+        run: |
+          git checkout -b FTR-pacman
+          git push -u origin FTR-pacman
+          git checkout -b FTR-ghost
+          git push -u origin FTR-ghost
+          git checkout -b FTR-map
+          git push -u origin FTR-map

--- a/.github/workflows/create_team.yaml
+++ b/.github/workflows/create_team.yaml
@@ -3,6 +3,7 @@
 name: Create Team
 
 on:
+  push:
   # Run this workflow with a manual trigger from GitHub Actions
   workflow_dispatch:
     inputs: 

--- a/.github/workflows/create_team.yaml
+++ b/.github/workflows/create_team.yaml
@@ -3,7 +3,6 @@
 name: Create Team
 
 on:
-  push:
   # Run this workflow with a manual trigger from GitHub Actions
   workflow_dispatch:
     inputs: 
@@ -29,8 +28,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TOKEN }}
         run: |
-          PARENT_TEAM=`gh api -X GET "/orgs/${{github.event.inputs.organization}}}/teams/students" --jq ".id"`
-          gh api -X POST "/orgs/${{github.event.inputs.organization}}}/teams" -F name=${{github.event.inputs.team}}} -F parent_team_id=$PARENT_TEAM
+          PARENT_TEAM=`gh api -X GET "/orgs/${{github.event.inputs.organization}}/teams/students" --jq ".id"`
+          gh api -X POST "/orgs/${{github.event.inputs.organization}}/teams" -F name=${{github.event.inputs.team}} -F parent_team_id=$PARENT_TEAM
 
       - name: Add Students to New Team
         env:

--- a/.github/workflows/create_team.yaml
+++ b/.github/workflows/create_team.yaml
@@ -1,9 +1,8 @@
 # This workflow will create a new team 
 
-name: Publish Project
+name: Create Team
 
 on:
-  push:
   # Run this workflow with a manual trigger from GitHub Actions
   workflow_dispatch:
     inputs: 

--- a/.github/workflows/update_team.yaml
+++ b/.github/workflows/update_team.yaml
@@ -4,7 +4,6 @@
 name: Update Team
 
 on:
-  push:
   # Run this workflow with a manual trigger from GitHub Actions
   workflow_dispatch:
     inputs: 

--- a/.github/workflows/update_team.yaml
+++ b/.github/workflows/update_team.yaml
@@ -1,0 +1,43 @@
+# This workflow will update a team repo with new code in the public
+# class repository
+
+name: Update Team
+
+on:
+  push:
+  # Run this workflow with a manual trigger from GitHub Actions
+  workflow_dispatch:
+    inputs: 
+      organization:
+        description: "name of the organization"
+        required: true
+
+      team:
+        description: "name of team"
+        required: true
+
+jobs:
+  # This job will update the team repository
+  update:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout Private Repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          repository: '${{github.event.inputs.organization}}/${{github.event.inputs.team}}'
+          token: ${{ secrets.TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.email "update-bot@umd.cmsc389T"
+          git config --global user.name "Update Bot"
+      
+      - name: Pull Upstream Changes
+        run: |
+          git remote add upstream https://github.com/${{github.event.inputs.organization}}/${{github.event.inputs.organization}}
+          git pull upstream main
+             
+      - name: Update With Upstream Changes
+        run: git push -u origin main

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ to run the scripts below.
   - [Publishing Projects](#Publishing-Projects)
     - [Publishing a Project](#Publishing-a-Project)
     - [Adding a Submodule to a Published Project](#Adding-a-Submodule-to-a-Project)
+  - [Creating a Student Team](#Creating-a-Student-Team)
+    - [Create a Student Team](#Create-a-Student-Team)
+    - [Update a Student Team](#Update-a-Student-Team)
 - [App Scripts](#App-Scripts)
   - [Adding Students](#Adding-Students) 
 - [Gradescope](#Gradescope)
@@ -97,6 +100,49 @@ adds that new repo as a submodule to an existing project.
 ```bash
 gh workflow run 'Publish Project Submodule' --ref main -f organization=cmsc389T-fall22 \
   -f project=P0 -f template=sagars729/git-java-setup-template --name=git-java-setup
+```
+
+## Creating a Student Team
+
+The group projects require creating individual student teams and 
+repositories. These teams are nested in the `students` team and 
+the repositories are mirrors of the public class repository. 
+
+### Create a Student Team
+
+The `Create Team` action creates a new team and repository for an
+individual team. 
+
+#### Parameters
+
+- organization: the name of the organization that we are updating
+- team: the name of the team that is being created
+- members: a space separated list of members
+
+#### Example
+
+```bash
+gh workflow run 'Create Team' --ref main -f organization=cmsc389T-fall22 \
+  -f team=Team0 -f members="sagars729 nkrishnan19"
+```
+
+### Update a Student Team
+
+The `Update Team` updates a team repository with new changes that
+have been pushed to the public repository. As new projects are
+released/updated, this action needs to be run to update all team 
+repos.
+
+#### Parameters
+
+- organization: the name of the organization that we are updating
+- team: the name of the team that is being created
+
+#### Example
+
+```bash
+gh workflow run 'Update Team' --ref main -f organization=cmsc389T-fall22 \
+  -f team=Team0
 ```
 
 # App Scripts


### PR DESCRIPTION
## Summary of Changes
In this PR, I have included 2 actions. The `Create Team` action is used to set up a new team in a class organization and the `Update Team` action is used to update teams with new changes in the public repositories. 

## Motivation
Each semester, we need to create teams that are linked to the `Students` team on GitHub and the public class repository. This involves complex set up and management (mirroring, multiple remotes) that can be abstracted with GitHub actions.

Closes https://github.com/sagars729/CMSC389T-Toolbox/issues/13

## Testing
I tested the actions in this PR by creating a new `Team0` in the cmsg289T-fall22 organization:

Create Team: https://github.com/sagars729/CMSC389T-Toolbox/actions/runs/3048780299
```bash
gh workflow run "Create Team" --ref add-create-team-action -f organization=cmsc389T-fall22 -f team=Team0 -f members="sagars729 nkrishnan19"
```

Update Team: https://github.com/sagars729/CMSC389T-Toolbox/actions/runs/3048809553
```bash
gh workflow run "Update Team" --ref add-create-team-action -f organization=cmsc389T-fall22 -f team=Team0
``` 

Both actions completed successfully. 