### PR TITLE
Publish team repos action

### DIFF
--- a/.github/workflows/hide_team_repo.yaml
+++ b/.github/workflows/hide_team_repo.yaml
@@ -15,8 +15,6 @@ on:
         description: "list of teams"
         required: true
 
-  push:
-
 jobs:
   # This job will patch the team repositories to be private
   publish:

--- a/.github/workflows/hide_team_repo.yaml
+++ b/.github/workflows/hide_team_repo.yaml
@@ -1,7 +1,7 @@
 # This workflow changes the permissions of team repositories
-# from private to public in a given organization
+# from public to private in a given organization
 
-name: Post Team Repos
+name: Hide Team Repos
 
 on:
   # Run this workflow with a manual trigger from GitHub Actions
@@ -18,16 +18,16 @@ on:
   push:
 
 jobs:
-  # This job will patch the team repositories to be public
+  # This job will patch the team repositories to be private
   publish:
     runs-on: ubuntu-latest
     
     steps:
-      - name: Patch team repos to be public
+      - name: Patch team repos to be private
         env:
           GH_TOKEN: ${{ secrets.TOKEN }}
         run: |
           for team in ${{github.event.inputs.teams}}
           do
-            gh api -X PATCH "/repos/${{github.event.inputs.organization}}/$team" -F private=false
+            gh api -X PATCH "/repos/${{github.event.inputs.organization}}/$team" -F private=true
           done

--- a/.github/workflows/post_team_repo.yaml
+++ b/.github/workflows/post_team_repo.yaml
@@ -1,0 +1,33 @@
+# This workflow changes the permissions of team repositories
+# from private to public in a given organization
+
+name: Post Team Repositories
+
+on:
+  # Run this workflow with a manual trigger from GitHub Actions
+  workflow_dispatch:
+    inputs: 
+      organization:
+        description: "name of the organization"
+        required: true
+
+      teams:
+        description: "list of teams"
+        required: true
+
+  push:
+
+jobs:
+  # This job will publish the project from the TA repo to the Public Repo
+  publish:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Patch team repos to be public
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          for team in ${{github.event.inputs.teams}}
+          do
+            gh api -X PATCH "/repos/${{github.event.inputs.organization}}/$team" -F private=false
+          done

--- a/.github/workflows/post_team_repo.yaml
+++ b/.github/workflows/post_team_repo.yaml
@@ -15,8 +15,6 @@ on:
         description: "list of teams"
         required: true
 
-  push:
-
 jobs:
   # This job will patch the team repositories to be public
   publish:

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ to run the scripts below.
 - We usually name our organizations `cmsc38{X}T-{season}{year}` e.x. `cmsc389T-fall22`
 - Make sure to add a picture for the organization! We usually choose from 
   [Octodex](https://octodex.github.com).
+- Make sure to set the base permissions for the organization to `None`, otherwise students
+  will be able to see the TA repo!
 
 ## Table of Contents
 
@@ -31,6 +33,9 @@ to run the scripts below.
   - [Creating a Student Team](#Creating-a-Student-Team)
     - [Create a Student Team](#Create-a-Student-Team)
     - [Update a Student Team](#Update-a-Student-Team)
+  - [Changing Team Repo Visibility](#Changing-Team-Repo-Visibility)
+    - [Post Team Repos](#Post-Team-Repos)
+    - [Hide Team Repos](#Hide-Team-Repos)
 - [App Scripts](#App-Scripts)
   - [Adding Students](#Adding-Students) 
 - [Gradescope](#Gradescope)
@@ -147,6 +152,45 @@ repos.
 ```bash
 gh workflow run 'Update Team' --ref main -f organization=cmsc389T-fall22 \
   -f team=Team0 -f branches='FTR-pacman FTR-ghost FTR-map'
+```
+
+## Changing Repo Visibility
+
+### Post Team Repos
+
+The `Post Team Repos` changes the visibility of team repositories from
+private to public. As students complete the PacMan project and need to
+be able to fork partner team repos, all team repos need to be made public.
+This can be done with this action.
+
+#### Parameters
+
+- organization: the name of the organization that we are updating
+- teams: space separated list of teams that are being changed to public
+
+#### Example
+
+```bash
+gh workflow run 'Post Team Repos' --ref main -f organization=cmsc389T-fall22 \
+  -f teams='Team0 Team1 Team2 Team3 Team4 Team5'
+```
+
+### Hide Team Repos
+
+The `Hide Team Repos` changes the visibility of team repositories from
+public to private. As the semester ends, all team repos need to be made 
+private before the next semester. This can be done with this action.
+
+#### Parameters
+
+- organization: the name of the organization that we are updating
+- teams: space separated list of teams that are being changed to private
+
+#### Example
+
+```bash
+gh workflow run 'Hide Team Repos' --ref main -f organization=cmsc389T-fall22 \
+  -f teams='Team0 Team1 Team2 Team3 Team4 Team5'
 ```
 
 # App Scripts


### PR DESCRIPTION
## Summary of Changes
In this change, I have added two GitHub Actions `Hide Team Repos` and `Post Team Repos` that toggle team repositories to private or public, respectively. I have also included documentation for both of these actions to the README.

## Motivation
We want to be able to post (shift visibility from private to public) and hide (shift visibility from public to private) team repos at key points in the semester. This change includes an action that allows us to add this functionality. 

Closes https://github.com/sagars729/CMSC389T-Toolbox/issues/20

## Testing
These actions were tested to hide all team repos from Spring 2022 and post all team repos from Fall 2022 for the PacMan CI project. 

https://github.com/sagars729/CMSC389T-Toolbox/actions/runs/3236763748
https://github.com/sagars729/CMSC389T-Toolbox/actions/runs/3235938766

